### PR TITLE
プロフィール画像の fetch のロジックの修正

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -258,8 +258,8 @@ paths:
 
 # 軽量化のため以下のエンドポイントは使わず、Cloudflare R2 のバケットを直接見に行く
   
-  # /api/users/{userName}/icon
-  # /api/users/{userName}/bgImage
+  # /api/users/{userName}/icon -> '#/components/schemas/url'
+  # /api/users/{userName}/bgImage -> '#/components/schemas/url'
 
   /api/users/{userName}/posts:
     get:
@@ -493,6 +493,13 @@ components:
       properties:
         userName:
           type: string
+    userSettings:
+      type: object
+      properties:
+        displayName:
+          type: string
+        biography:
+          type: string
     userDisplay:
       type: object
       properties:
@@ -500,12 +507,9 @@ components:
           type: string
         displayName:
           type: string
-    userSettings:
-      type: object
-      properties:
-        displayName:
+        iconUrl:
           type: string
-        biography:
+        bgImageUrl:
           type: string
     profile:
       type: object
@@ -515,6 +519,10 @@ components:
         displayName:
           type: string
         biography:
+          type: string
+        iconUrl:
+          type: string
+        bgImageUrl:
           type: string
     user:
       type: object
@@ -529,6 +537,10 @@ components:
           type: string
           format: date-time
         followingStatus:
+          type: string
+        iconUrl:
+          type: string
+        bgImageUrl:
           type: string
     userDetail:
       type: object
@@ -546,6 +558,15 @@ components:
           type: integer
         followingStatus:
           type: string
+        iconUrl:
+          type: string
+        bgImageUrl:
+          type: string
+    url: 
+      type: object
+      properties:
+        url:
+          type: string
     postId:
       type: object
       properties:
@@ -562,7 +583,7 @@ components:
         postId:
           type: string
         poster:
-          $ref: '#/components/schemas/user'
+          $ref: '#/components/schemas/userDisplay'
         content:
           type: string
         likes:
@@ -580,7 +601,7 @@ components:
         postId:
           type: string
         poster:
-          $ref: '#/components/schemas/user'
+          $ref: '#/components/schemas/userDisplay'
         content:
           type: string
         likes:
@@ -607,7 +628,7 @@ components:
         commentId:
           type: string
         commenter:
-          $ref: '#/components/schemas/user'
+          $ref: '#/components/schemas/userDisplay'
         content:
           type: string
         replies:
@@ -630,7 +651,7 @@ components:
         replyId:
           type: string
         replier:
-          $ref: '#/components/schemas/user'
+          $ref: '#/components/schemas/userDisplay'
         content:
           type: string
         createdAt:

--- a/src/app/(auth)/posts/[postId]/_components/comment.tsx
+++ b/src/app/(auth)/posts/[postId]/_components/comment.tsx
@@ -4,7 +4,6 @@ import path from "path";
 import { useRouter } from "next/navigation";
 import { Box, Flex, Image, Text, useColorModeValue } from "@chakra-ui/react";
 import { components } from "@/lib/openapi/schema";
-import { userIconUrl } from "@/lib/image";
 import { getAboutDate } from "@/utils/time";
 import Replies from "@/app/(auth)/posts/[postId]/_components/replies";
 
@@ -38,7 +37,7 @@ const Comment = ({ comment, commentCallback }: Props) => {
           onClick={() =>
             router.push(path.join("/users", comment?.commenter?.userName ? comment.commenter.userName : ""))
           }>
-          <Image src={userIconUrl(comment?.commenter?.userName!)} w="45px" h="45px" alt="" />
+          <Image src={comment?.commenter?.iconUrl} w="45px" h="45px" alt="" />
         </Box>
         <Flex direction="column" flex={1}>
           <Flex direction="row" gap="4px">

--- a/src/app/(auth)/posts/[postId]/_components/comments.tsx
+++ b/src/app/(auth)/posts/[postId]/_components/comments.tsx
@@ -6,7 +6,6 @@ import { useAuthContext } from "@/components/contexts/AuthProvider";
 import { components } from "@/lib/openapi/schema";
 import useCommentModal from "@/hooks/commentModal";
 import Comment from "@/app/(auth)/posts/[postId]/_components/comment";
-import { userIconUrl } from "@/lib/image";
 
 type Props = {
   postId: string;
@@ -47,7 +46,7 @@ const Comments = ({ postId, comments, commentsCallback }: Props) => {
         <Flex direction="row" alignItems="center" padding="12px">
           <Box w="45px" h="45px" borderRadius="full" backgroundColor="gray.200" overflow="hidden">
             <Skeleton isLoaded={authContext.currentUser != undefined && !isLoading}>
-              <Image src={userIconUrl(data?.userName!)} w="45px" h="45px" alt="" />
+              <Image src={data?.iconUrl} w="45px" h="45px" alt="" />
             </Skeleton>
           </Box>
           <Button

--- a/src/app/(auth)/posts/[postId]/_components/reply.tsx
+++ b/src/app/(auth)/posts/[postId]/_components/reply.tsx
@@ -2,7 +2,6 @@ import path from "path";
 import { useRouter } from "next/navigation";
 import { Box, Flex, Image, Text } from "@chakra-ui/react";
 import { components } from "@/lib/openapi/schema";
-import { userIconUrl } from "@/lib/image";
 import { getAboutDate } from "@/utils/time";
 
 type Props = {
@@ -23,7 +22,7 @@ const Reply = ({ reply, replyCallback }: Props) => {
         backgroundColor="gray.200"
         overflow="hidden"
         onClick={() => router.push(path.join("/users", reply?.replier?.userName ? reply.replier.userName : ""))}>
-        <Image src={userIconUrl(reply?.replier?.userName!)} w="45px" h="45px" alt="" />
+        <Image src={reply?.replier?.iconUrl} w="45px" h="45px" alt="" />
       </Box>
       <Flex direction="column" gap="4px" flex="1">
         <Flex direction="column">

--- a/src/app/(auth)/posts/[postId]/page.tsx
+++ b/src/app/(auth)/posts/[postId]/page.tsx
@@ -20,7 +20,6 @@ import { useAuthContext } from "@/components/contexts/AuthProvider";
 import BackButtonHeader from "@/components/ui/backButtonHeader";
 import client from "@/lib/openapi";
 import { components } from "@/lib/openapi/schema";
-import { userIconUrl } from "@/lib/image";
 import { getFormattedDate } from "@/utils/time";
 import Comments from "@/app/(auth)/posts/[postId]/_components/comments";
 
@@ -62,7 +61,7 @@ const PostPage = ({ params }: { params: { postId: string } }) => {
               overflow="hidden"
               onClick={() => router.push(path.join("/users", data?.poster?.userName ? data.poster.userName : ""))}>
               <Skeleton isLoaded={authContext.currentUser != undefined && !isLoading}>
-                <Image src={userIconUrl(data?.poster?.userName!)} w="45px" h="45px" alt="" />
+                <Image src={data?.poster?.iconUrl} w="45px" h="45px" alt="" />
               </Skeleton>
             </Box>
             <Flex direction="column" gap="4px" flex="1">

--- a/src/app/(auth)/settings/profile/page.tsx
+++ b/src/app/(auth)/settings/profile/page.tsx
@@ -16,7 +16,7 @@ import useImageCrop from "@/hooks/imageCrop/useImageCrop";
 import client from "@/lib/openapi";
 import { components } from "@/lib/openapi/schema";
 import domainConsts from "@/constants/domain";
-import { postUserIconUrl, postUserBgImageUrl, userIconUrl, userBgImageUrl } from "@/lib/image";
+import { postUserIconUrl, postUserBgImageUrl } from "@/lib/image";
 
 const schema = z.object({
   displayName: z
@@ -118,7 +118,7 @@ const ProfileSettingsPage = () => {
               ) : !data || !data.userName || error || isLoading ? (
                 <Box w="100%" aspectRatio={3} cursor="pointer" />
               ) : (
-                <Image src={userBgImageUrl(data.userName)} w="100%" alt="" aspectRatio={3} cursor="pointer" />
+                <Image src={data.bgImageUrl} w="100%" alt="" aspectRatio={3} cursor="pointer" />
               )}
               <Input type="file" accept="image/*" display="none" onChange={onBgImageFileChange} />
               {bgImageModalCropper}
@@ -148,7 +148,7 @@ const ProfileSettingsPage = () => {
                 ) : (
                   // TODO: 謎の枠線ができてしまうので onerror="this.src=(代替のURL)" などで対処する
                   // TODO: 以下を nocache にする (プロフィールを変更しても以前の画像が表示されてしまうため)
-                  <Image src={userIconUrl(data.userName)} w="80px" h="80px" alt="" cursor="pointer" />
+                  <Image src={data.iconUrl} w="80px" h="80px" alt="" cursor="pointer" />
                 )}
                 <Input type="file" accept="image/*" display="none" onChange={onIconFileChange} />
                 {iconModalCropper}

--- a/src/app/(auth)/users/[userName]/page.tsx
+++ b/src/app/(auth)/users/[userName]/page.tsx
@@ -21,7 +21,6 @@ import { useAuthContext } from "@/components/contexts/AuthProvider";
 import Posts from "@/components/ui/posts";
 import client from "@/lib/openapi";
 import { components } from "@/lib/openapi/schema";
-import { userBgImageUrl, userIconUrl } from "@/lib/image";
 import domainConsts from "@/constants/domain";
 import PageBackButton from "@/components/elements/pageBackButton";
 import PostButton from "@/components/elements/postButton";
@@ -79,7 +78,7 @@ const UserPage = ({ params }: { params: { userName: string } }) => {
             {!userData || !userData.userName || userError || isLoadingUser ? (
               <Box w="100%" aspectRatio={3} />
             ) : (
-              <Image src={userBgImageUrl(userData.userName)} w="100%" aspectRatio={3} alt="" />
+              <Image src={userData.bgImageUrl} w="100%" aspectRatio={3} alt="" />
             )}
           </Skeleton>
         </Box>
@@ -102,7 +101,7 @@ const UserPage = ({ params }: { params: { userName: string } }) => {
                 ) : (
                   // TODO: 謎の枠線ができてしまうので onerror="this.src=(代替のURL)" などで対処する
                   // TODO: 以下を nocache にする (プロフィールを変更しても以前の画像が表示されてしまうため)
-                  <Image src={userIconUrl(userData.userName)} w="80px" h="80px" alt="" />
+                  <Image src={userData.iconUrl} w="80px" h="80px" alt="" />
                 )}
               </Skeleton>
             </Box>

--- a/src/components/ui/post.tsx
+++ b/src/components/ui/post.tsx
@@ -6,7 +6,6 @@ import { Flex, Box, Text, Tooltip, Image, useColorModeValue } from "@chakra-ui/r
 import { FaRegCommentAlt, FaHeart, FaRegHeart } from "react-icons/fa";
 import client from "@/lib/openapi";
 import { components } from "@/lib/openapi/schema";
-import { userIconUrl } from "@/lib/image";
 import { getAboutDate } from "@/utils/time";
 
 type Props = { post: components["schemas"]["post"]; postCallback?: (post: components["schemas"]["post"]) => void };
@@ -39,7 +38,7 @@ const Post = ({ post, postCallback }: Props) => {
         backgroundColor="gray.200"
         overflow="hidden"
         onClick={() => router.push(path.join("/users", post.poster?.userName ? post.poster?.userName : ""))}>
-        <Image src={userIconUrl(post.poster?.userName!)} w="45px" h="45px" alt="" />
+        <Image src={post.poster?.iconUrl} w="45px" h="45px" alt="" />
       </Box>
       <Flex direction="column" gap="4px" flex="1">
         <Flex

--- a/src/components/ui/user.tsx
+++ b/src/components/ui/user.tsx
@@ -6,7 +6,6 @@ import { Flex, Box, Text, Button, IconButton, Image, useColorModeValue } from "@
 import { CloseIcon } from "@chakra-ui/icons";
 import client from "@/lib/openapi";
 import { components } from "@/lib/openapi/schema";
-import { userIconUrl } from "@/lib/image";
 import domainConsts from "@/constants/domain";
 import { adjustBio } from "@/utils/stringOperation";
 
@@ -49,7 +48,7 @@ const User = ({ user, userCallback, enableReject }: Props) => {
         backgroundColor="gray.200"
         overflow="hidden"
         onClick={() => router.push(path.join("/users", user.userName ? user.userName : ""))}>
-        <Image src={userIconUrl(user.userName!)} w="45px" h="45px" alt="" />
+        <Image src={user.iconUrl} w="45px" h="45px" alt="" />
       </Box>
       <Flex direction="column" gap="4px" flex="1">
         <Flex direction="row" justifyContent="space-between">

--- a/src/hooks/commentModal.tsx
+++ b/src/hooks/commentModal.tsx
@@ -27,7 +27,6 @@ import { useAuthContext } from "@/components/contexts/AuthProvider";
 import { ControlledTextarea } from "@/components/elements/ControlledTextarea";
 import client from "@/lib/openapi";
 import { components } from "@/lib/openapi/schema";
-import { userIconUrl } from "@/lib/image";
 import domainConsts from "@/constants/domain";
 
 const schema = z.object({
@@ -111,7 +110,7 @@ const useCommentModal = (postId: string, submitCallback?: (comment: components["
                 {!data || !data.userName || error || isLoading ? (
                   <Box w="100%" aspectRatio={3} />
                 ) : (
-                  <Image src={userIconUrl(data?.userName)} w="35px" h="35px" alt="" />
+                  <Image src={data?.iconUrl} w="35px" h="35px" alt="" />
                 )}
               </Skeleton>
             </Box>

--- a/src/hooks/postModal.tsx
+++ b/src/hooks/postModal.tsx
@@ -26,7 +26,6 @@ import {
 } from "@chakra-ui/react";
 import { useAuthContext } from "@/components/contexts/AuthProvider";
 import client from "@/lib/openapi";
-import { userIconUrl } from "@/lib/image";
 import domainConsts from "@/constants/domain";
 import { ControlledTextarea } from "@/components/elements/ControlledTextarea";
 
@@ -111,7 +110,7 @@ const usePostModal = (submitCallback?: (comment: components["schemas"]["post"]) 
                 {!data || !data.userName || error || isLoading ? (
                   <Box w="100%" aspectRatio={3} />
                 ) : (
-                  <Image src={userIconUrl(data?.userName)} w="35px" h="35px" alt="" />
+                  <Image src={data?.iconUrl} w="35px" h="35px" alt="" />
                 )}
               </Skeleton>
             </Box>

--- a/src/hooks/replyModal.tsx
+++ b/src/hooks/replyModal.tsx
@@ -27,7 +27,6 @@ import { useAuthContext } from "@/components/contexts/AuthProvider";
 import { ControlledTextarea } from "@/components/elements/ControlledTextarea";
 import client from "@/lib/openapi";
 import { components } from "@/lib/openapi/schema";
-import { userIconUrl } from "@/lib/image";
 import domainConsts from "@/constants/domain";
 
 const schema = z.object({
@@ -111,7 +110,7 @@ const useReplyModal = (commentId: string, submitCallback?: (reply: components["s
                 {!data || !data.userName || error || isLoading ? (
                   <Box w="100%" aspectRatio={3} />
                 ) : (
-                  <Image src={userIconUrl(data?.userName)} w="35px" h="35px" alt="" />
+                  <Image src={data?.iconUrl} w="35px" h="35px" alt="" />
                 )}
               </Skeleton>
             </Box>

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -2,11 +2,6 @@ import { getAuth } from "firebase/auth";
 import { firebaseApp } from "@lib/firebase";
 import { publicEnv } from "@/constants/env";
 
-const userIconUrl = (userName: string) => new URL(`/images/users/${userName}/icon.png`, publicEnv.IMAGE_URL).href;
-
-const userBgImageUrl = (userName: string) =>
-  new URL(`/images/users/${userName}/background.png`, publicEnv.IMAGE_URL).href;
-
 const postUserIconUrl = async (blob: Blob) => {
   const auth = getAuth(firebaseApp);
   const idToken = await auth.currentUser?.getIdToken();
@@ -39,4 +34,4 @@ const postUserBgImageUrl = async (blob: Blob) => {
   });
 };
 
-export { userIconUrl, userBgImageUrl, postUserIconUrl, postUserBgImageUrl };
+export { postUserIconUrl, postUserBgImageUrl };

--- a/src/lib/openapi/schema.d.ts
+++ b/src/lib/openapi/schema.d.ts
@@ -480,18 +480,22 @@ export interface components {
     userName: {
       userName?: string;
     };
-    userDisplay: {
-      userName?: string;
-      displayName?: string;
-    };
     userSettings: {
       displayName?: string;
       biography?: string;
+    };
+    userDisplay: {
+      userName?: string;
+      displayName?: string;
+      iconUrl?: string;
+      bgImageUrl?: string;
     };
     profile: {
       userName?: string;
       displayName?: string;
       biography?: string;
+      iconUrl?: string;
+      bgImageUrl?: string;
     };
     user: {
       userName?: string;
@@ -500,6 +504,8 @@ export interface components {
       /** Format: date-time */
       createdAt?: string;
       followingStatus?: string;
+      iconUrl?: string;
+      bgImageUrl?: string;
     };
     userDetail: {
       userName?: string;
@@ -509,6 +515,11 @@ export interface components {
       createdAt?: string;
       mutuals?: number;
       followingStatus?: string;
+      iconUrl?: string;
+      bgImageUrl?: string;
+    };
+    url: {
+      url?: string;
     };
     postId: {
       postId?: string;
@@ -518,7 +529,7 @@ export interface components {
     };
     post: {
       postId?: string;
-      poster?: components["schemas"]["user"];
+      poster?: components["schemas"]["userDisplay"];
       content?: string;
       likes?: number;
       liked?: boolean;
@@ -528,7 +539,7 @@ export interface components {
     };
     postDetail: {
       postId?: string;
-      poster?: components["schemas"]["user"];
+      poster?: components["schemas"]["userDisplay"];
       content?: string;
       likes?: number;
       liked?: boolean;
@@ -542,7 +553,7 @@ export interface components {
     };
     comment: {
       commentId?: string;
-      commenter?: components["schemas"]["user"];
+      commenter?: components["schemas"]["userDisplay"];
       content?: string;
       replies?: components["schemas"]["reply"][];
       /** Format: date-time */
@@ -554,7 +565,7 @@ export interface components {
     };
     reply: {
       replyId?: string;
-      replier?: components["schemas"]["user"];
+      replier?: components["schemas"]["userDisplay"];
       content?: string;
       /** Format: date-time */
       createdAt?: string;


### PR DESCRIPTION
## Summary
- プロフィール画像を更新するごとに画像の URL が変更される仕様に変更
- これにより画像を変更してもキャッシュを見なくなるので即座に新しい画像が反映される