### PR TITLE
ビルド時に localStorage が見つからない問題の修正

### DIFF
--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -11,6 +11,7 @@ import SetUpDialog from "@/components/handle/setUpDialog";
 import TitleHeader from "@/components/ui/titleHeader";
 import domainConsts from "@/constants/domain";
 import useLocalStorage from "@/hooks/localStorage";
+import { LocalStorage } from "@/lib/localStorage";
 import Notification from "@app/notifications/_components/notification";
 
 const NotificationsPage = () => {
@@ -39,7 +40,7 @@ const NotificationsPage = () => {
       return;
     }
 
-    const lastConfirmedPostNotificationId = localStorage.getItem("lastConfirmedPostNotificationId") ?? "";
+    const lastConfirmedPostNotificationId = LocalStorage.getItem("lastConfirmedPostNotificationId") ?? "";
     const newestPostNotificationId = res.data.postNotifications?.[0].postNotificationId ?? "";
 
     setLastConfirmedPostNotificationId(

--- a/src/hooks/localStorage.tsx
+++ b/src/hooks/localStorage.tsx
@@ -1,16 +1,19 @@
+"use client";
+
 import { useEffect, useState } from "react";
+import { LocalStorage } from "@/lib/localStorage";
 
 const useLocalStorage = (key: string) => {
   const [value, setValue] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    setValue(window.localStorage.getItem(key));
+    setValue(LocalStorage.getItem(key) ?? null);
     setIsLoading(false);
   }, []);
 
   const setValueAndStorage = (newValue: string) => {
-    window.localStorage.setItem(key, newValue);
+    LocalStorage.setItem(key, newValue);
     setValue(newValue);
   };
 

--- a/src/hooks/menu.tsx
+++ b/src/hooks/menu.tsx
@@ -18,6 +18,7 @@ import {
 import { LuSend } from "react-icons/lu";
 import { useAuthContext } from "@components/contexts/AuthProvider";
 import { components } from "@/lib/openapi/schema";
+import { LocalStorage } from "@/lib/localStorage";
 import usePostModal from "@/hooks/post/postModal";
 import useSignOutDialog from "@hooks/signOutDialog";
 
@@ -45,7 +46,7 @@ const useMenu = ({ postModalOpenCallback, signOutDialogOpenCallback, onMenuClose
     authContext.currentUser ? "/api/posts/notifications?limit=1" : null
   );
 
-  const lastConfirmedPostNotificationId = localStorage.getItem("lastConfirmedPostNotificationId") ?? "";
+  const lastConfirmedPostNotificationId = LocalStorage.getItem("lastConfirmedPostNotificationId") ?? "";
   const newestPostNotificationId = notificationsData?.postNotifications?.[0].postNotificationId ?? "";
   const isNotificationsExist = newestPostNotificationId > lastConfirmedPostNotificationId;
 

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,7 @@
 import { getApp, getApps, initializeApp } from "firebase/app";
 import { publicEnv } from "@/constants/env";
 import { GoogleAuthProvider, getAuth, signOut as firebaseSignOut, signInWithPopup } from "firebase/auth";
+import { LocalStorage } from "@lib/localStorage";
 import { ANNOUNCEMENT_LOCALSTORAGE_KEY } from "@/constants/announcement";
 
 const firebaseConfig = {
@@ -19,7 +20,7 @@ const signIn = async (afterAuth?: () => any) => {
   const provider = new GoogleAuthProvider();
   const auth = getAuth(firebaseApp);
   const credential = await signInWithPopup(auth, provider);
-  localStorage.removeItem(ANNOUNCEMENT_LOCALSTORAGE_KEY);
+  LocalStorage.removeItem(ANNOUNCEMENT_LOCALSTORAGE_KEY);
   afterAuth?.();
   return credential;
 };
@@ -27,7 +28,7 @@ const signIn = async (afterAuth?: () => any) => {
 const signOut = async (afterAuth?: () => any) => {
   const auth = getAuth(firebaseApp);
   const credential = await firebaseSignOut(auth);
-  localStorage.removeItem(ANNOUNCEMENT_LOCALSTORAGE_KEY);
+  LocalStorage.removeItem(ANNOUNCEMENT_LOCALSTORAGE_KEY);
   afterAuth?.();
   return credential;
 };

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -1,0 +1,22 @@
+class LocalStorageClass {
+  setItem(key: string, value: any) {
+    if (typeof window !== "undefined") {
+      localStorage.setItem(key, value);
+    }
+  }
+
+  getItem(key: string) {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem(key);
+    }
+  }
+
+  removeItem(key: string) {
+    if (typeof window !== "undefined") {
+      localStorage.removeItem(key);
+    }
+  }
+}
+const LocalStorage = new LocalStorageClass();
+
+export { LocalStorage };


### PR DESCRIPTION
## Description
- localStorage を使っているのは全てクライアントコンポーネントのつもりではあったが、なぜかビルドがこけていた
- localStorage にアクセスするときは `window` が存在しているかを毎回見るように修正 ( `localStorage` は `window.localStorage` と同一であるため )
